### PR TITLE
Update to bundle-visualizer to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "latest-publish-id": "npm run latest-staging --silent | jq '.queryResult[0].publicationId' -r",
     "publish": "expo publish --release-channel staging-`npm run current-version --silent`",
     "promote-prod": "expo publish:set --publish-id `npm run latest-publish-id --silent` --release-channel production-`npm run current-version --silent`",
-    "viz": "npx react-native-bundle-visualizer --expo managed",
+    "viz": "npx react-native-bundle-visualizer@2",
     "deploy-staging": "if [ $(npm run last-prod-release --silent) = $(npm run current-prod-release --silent) ]; then if [ $(npm run last-eas-build --silent) = $(npm run current-eas-build --silent) ]; then npm run publish; else npm run eas-build-submit-ci; fi; fi",
     "deploy-production": "npm run eas-build-submit-ci-prod"
   },


### PR DESCRIPTION
Fix this error

```
$ npx react-native-bundle-visualizer --expo managed
Need to install the following packages:
  react-native-bundle-visualizer
Ok to proceed? (y) y
Generating bundle...
The "--expo" command is no longer needed for Expo SDK 41 or higher. When using Expo SDK 40 or lower, please use `react-native-bundle-visualizer@2`.
                    Welcome to Metro!
              Fast - Scalable - Integrated
```